### PR TITLE
Filter out deleted and completed jobs in Job-PI mappigs

### DIFF
--- a/components/mapping/pi-job-mapping.tsx
+++ b/components/mapping/pi-job-mapping.tsx
@@ -41,11 +41,25 @@ export default function PiJobMappingPage() {
       const jobsData = await jobsResponse.json();
       const mappingsResult = await mappingsResponse.json();
       
+      // Filter out deleted jobs and completed jobs
+      const filteredJobs = jobsData.data.filter((job: any) => 
+        // Keep job if isDeleted is false or doesn't exist AND isDone is false
+        (job.isDeleted === false || job.isDeleted === undefined) && 
+        job.isDone === false
+      );
+      
       setPisList(pisData.data || []);
-      setJobsList(jobsData.data || []);
+      setJobsList(filteredJobs || []);
       
       if (mappingsResult.success) {
-        const tableData = convertJPMappingToTableData(mappingsResult.data, pisData.data, jobsData.data);
+        // Only convert mappings that reference non-deleted and active jobs
+        const activeJobIds = new Set(filteredJobs.map((job: any) => job._id));
+        const filteredMappings = mappingsResult.data.filter((mapping: any) => 
+          // Only include mappings where the jobId is in our filtered job list
+          activeJobIds.has(mapping.jobId)
+        );
+        
+        const tableData = convertJPMappingToTableData(filteredMappings, pisData.data, filteredJobs);
         setData(tableData);
       } else {
         setError(mappingsResult.error);


### PR DESCRIPTION
In the job-PI mapping table, only show mappings for jobs where isDeleted flag is false or doesn't exist or jobs where `isDone` is false.