### PR TITLE
Fix job dialog reopening issue after edits

### DIFF
--- a/app/api/jobs/[id]/route.ts
+++ b/app/api/jobs/[id]/route.ts
@@ -67,31 +67,35 @@ export async function PUT(
     const { id } = await params;
     const updateData = await request.json();
 
+    // Store the initial update result
     let updatedJob = await jobService.updateJob(id, userId!, updateData);
-
-  
-    if(updateData && !( 'nextTaskId' in updateData)) { //set first task in the array as next task if the next task is not beig set as NONE/specific value
-      updatedJob = await jobService.setFirstTaskAsNextTaskId(id);
-      if (!updatedJob) {
-        return NextResponse.json(
-          {
-            success: false,
-            error: 'Job not found'
-          },
-          { status: 404 }
-        );
-      } 
-    }
-
-    const forceUpdateTasks = request.nextUrl.searchParams.get('updateTasks') === 'true';
-
-    if(forceUpdateTasks && updatedJob) {
-        await updateTasksStatus(updateData, updatedJob, userId!);
-    }
-  
     
+    // Check if the job wasn't found
+    if (!updatedJob) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Job not found'
+        },
+        { status: 404 }
+      );
+    }
+  
+    // Set first task as next task if needed
+    if(updateData && !('nextTaskId' in updateData)) { 
+      const jobWithNextTask = await jobService.setFirstTaskAsNextTaskId(id);
+      if (jobWithNextTask) {
+        updatedJob = jobWithNextTask;
+      }
+    }
 
-
+    // Update tasks status if requested
+    const forceUpdateTasks = request.nextUrl.searchParams.get('updateTasks') === 'true';
+    if(forceUpdateTasks && updatedJob) {
+      await updateTasksStatus(updateData, updatedJob, userId!);
+    }
+  
+    // Return the final updated job
     return NextResponse.json({
       success: true,
       data: updatedJob

--- a/components/jobs/job-feed-view.tsx
+++ b/components/jobs/job-feed-view.tsx
@@ -756,6 +756,9 @@ export default function JobsPage() {
           title: "Success",
           description: "Job updated successfully",
         });
+        // Make sure we clear the editing job state to properly close the dialog
+        setEditingJob(undefined);
+        // Then fetch updated jobs
         fetchJobs();
       } else {
         throw new Error(result.error);


### PR DESCRIPTION
When a job is edited, it re-opens the edit job dialog box. This PR fixes that.
