### PR TITLE
Remove outcome deadline from onboading as its inconsistent

### DIFF
--- a/app/backstage/onboarding/page.tsx
+++ b/app/backstage/onboarding/page.tsx
@@ -772,14 +772,6 @@ export default function OnboardingPage() {
                                       </span>{" "}
                                       {outcome.targetValue}
                                     </p>
-                                    <p>
-                                      <span className="font-medium">
-                                        Deadline:
-                                      </span>{" "}
-                                      {new Date(
-                                        outcome.deadline,
-                                      ).toLocaleDateString()}
-                                    </p>
                                     <div className="mb-3 text-sm text-gray-700">
                                       <p>{outcome.notes}</p>
                                     </div>


### PR DESCRIPTION
FE sometimes shows outcome deadlines 3 months in the future, sometimes not (BE always sets it in the future), so removing it in FE to avoid confusion for the user.