### PR TITLE
Delete do date of task in duplicated job

### DIFF
--- a/lib/services/job-duplication.service.ts
+++ b/lib/services/job-duplication.service.ts
@@ -72,6 +72,7 @@ export class JobDuplicationService {
         };
         delete newTask._id;
         delete newTask.id;
+        delete newTask.date;
 
         // Create the task
         const taskResult = await this.taskService.createTask(newTask, userId);


### PR DESCRIPTION
When a job is duplicated, a common use case is to change the "due date" for the job, so the corresponding tasks' dates should also be reset.