### PR TITLE
manual validation check in task dialog

### DIFF
--- a/components/tasks/feed/tasks.tsx
+++ b/components/tasks/feed/tasks.tsx
@@ -125,6 +125,11 @@ export function NextTasks({
     return jobs[jobId].impact || 0;
   };
 
+  // Helper function to get a consistent unique ID for each task
+  const getTaskId = (task: any, index: number) => {
+    return task._id || task.id || `task-${index}`;
+  };
+
   if (loading) {
     return <NextTasksSkeletonLoader />;
   }
@@ -141,11 +146,12 @@ export function NextTasks({
 
   return (
     <div className="space-y-4 w-full">
-      {tasks.map((task) => {
+      {tasks.map((task, index) => {
+        const taskId = getTaskId(task, index);
         const taskIsNext = isNextTask(task);
         return (
           <Card
-            key={task._id}
+            key={taskId} // Use just the taskId, which now includes index as fallback
             className={`overflow-hidden hover:shadow-md transition-shadow w-full ${
               taskIsNext ? "border-orange-500 border-2" : ""
             }`}
@@ -156,7 +162,7 @@ export function NextTasks({
                   <div className="pt-1">
                     <Checkbox
                       checked={task.completed === true}
-                      onCheckedChange={(value) => onComplete(task._id, !!value)}
+                      onCheckedChange={(value) => onComplete(taskId, !!value)}
                       aria-label="Mark as completed"
                     />
                   </div>
@@ -261,7 +267,7 @@ export function NextTasks({
                                 "Are you sure you want to delete this task?",
                               )
                             ) {
-                              onDeleteTask(task._id);
+                              onDeleteTask(taskId);
                             }
                           }}
                           title="Delete task"
@@ -380,4 +386,3 @@ function NextTasksSkeletonLoader() {
 }
 
 export default NextTasks;
-

--- a/components/tasks/tasks-dialog-jobselector.tsx
+++ b/components/tasks/tasks-dialog-jobselector.tsx
@@ -84,6 +84,7 @@ export function TaskDialog({
   // Job State Management
   const [jobId, setJobId] = useState<string | undefined>(undefined);
   const [isJobDialogOpen, setIsJobDialogOpen] = useState(false);
+  const [jobError, setJobError] = useState<string | null>(null);
 
   const { toast } = useToast();
 
@@ -244,6 +245,13 @@ export function TaskDialog({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!jobId || jobId === "none") {
+      setJobError("Please assign a job to this task.");
+      return;
+    } else {
+      setJobError(null);
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -354,7 +362,7 @@ export function TaskDialog({
               {/* Title */}
               <div className="grid grid-cols-4 items-center gap-4">
                 <Label htmlFor="title" className="text-right">
-                  Title
+                  Title <span className="text-red-500">*</span>
                 </Label>
                 <Input
                   id="title"
@@ -369,12 +377,14 @@ export function TaskDialog({
               {!propJobId && (
                 <div className="grid grid-cols-4 items-center gap-4">
                   <Label htmlFor="job" className="text-right">
-                    Job
+                    Job <span className="text-red-500">*</span>
                   </Label>
                   <div className="col-span-3 space-y-2">
                     <Select
                       value={jobId || "none"}
+                      required
                       onValueChange={(value) => {
+                        setJobError(null);
                         if (value === "create") {
                           setIsJobDialogOpen(true);
                         } else {
@@ -397,6 +407,9 @@ export function TaskDialog({
                         <SelectItem value="create">+ Create New Job</SelectItem>
                       </SelectContent>
                     </Select>
+                    {jobError && (
+                      <p className="text-sm text-red-500 mt-1">{jobError}</p>
+                    )}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
**Tasks-dialog-jobselector.tsx:**
Couldn't add a tooltip directly to the Job field (as done for the title field) because the <Select> element used for Job is not native to HTML so the  tooltips with native HTML validation don't work. 

So I added manual validation logic inside handleSubmit() and conditionally rendered the error message. Now the form won't submit without a job assigned to the task and shows an error message which would go away when a job is assigned.

**Tasks.tsx**
Was getting errors on the NextTasks component. Figured some tasks either did not have a _id property or there were duplicate _id values which was causing React’s “unique key” error.
I added a helper function for a fallback chain: first check tasks._id, if not present, use [task.id](http://task.id/), still not present, then generate task-${index} as last resort.