### PR TITLE
added filtering functionality to backstage mapping tables

### DIFF
--- a/components/mapping/pi-job-mapping.tsx
+++ b/components/mapping/pi-job-mapping.tsx
@@ -8,6 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@clerk/nextjs";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function PiJobMappingPage() {
   const [data, setData] = useState<MappingJP[]>([]);
@@ -17,6 +19,8 @@ export default function PiJobMappingPage() {
   const [editingPI, setEditingPI] = useState<MappingJP | undefined>(undefined);
   const [pisList, setPisList] = useState<any[]>([]);
   const [jobsList, setJobsList] = useState<any[]>([]);
+  const [piSearchTerm, setPiSearchTerm] = useState("");
+  const [jobSearchTerm, setJobSearchTerm] = useState("");
   
   const { toast } = useToast();
   const { user, isLoaded } = useUser();
@@ -198,6 +202,14 @@ export default function PiJobMappingPage() {
     );
   }
 
+  const filteredData = data.filter((item) => {
+    const matchesPI = piSearchTerm === "" || 
+      item.piName.toLowerCase().includes(piSearchTerm.toLowerCase());
+    const matchesJob = jobSearchTerm === "" || 
+      item.jobName.toLowerCase().includes(jobSearchTerm.toLowerCase());
+    return matchesPI && matchesJob;
+  });
+
   return (
     <div className="container mx-auto py-6">
       <div className="flex justify-between items-center mb-6">
@@ -207,10 +219,33 @@ export default function PiJobMappingPage() {
           Add Mapping
         </Button>
       </div>
-      
+      <div className="flex gap-4 mb-4"> 
+        <div className="flex-1">
+          <Label htmlFor="job-search" className="text-sm font-medium mb-2 block">
+            Search by Job name
+          </Label>
+          <Input
+            placeholder="Search by Job name..."
+            value={jobSearchTerm}
+            onChange={(e) => setJobSearchTerm(e.target.value)}
+            className="max-w-sm"
+          />
+        </div>
+        <div className="flex-1">
+          <Label htmlFor="pi-search" className="text-sm font-medium mb-2 block">
+            Search by Output name
+          </Label>
+          <Input
+            placeholder="Search by Output name..."
+            value={piSearchTerm}
+            onChange={(e) => setPiSearchTerm(e.target.value)}
+            className="max-w-sm"
+          />
+        </div>
+      </div>
       <MappingJPTable 
         columns={columns(handleOpenEdit, handleDelete)} 
-        data={data} 
+        data={filteredData} 
       />
 
       <MappingDialog

--- a/components/mapping/pi-qbo-mapping.tsx
+++ b/components/mapping/pi-qbo-mapping.tsx
@@ -11,6 +11,8 @@ import { PIs } from "@/lib/models/pi.model";
 import { QBOs } from "@/lib/models/qbo.model";
 import { useUser } from "@clerk/nextjs";
 import { Plus } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function PIQBOMappingsPage() {
   const [mappings, setMappings] = useState<PIQBOMapping[]>([]);
@@ -21,6 +23,8 @@ export default function PIQBOMappingsPage() {
   const [dialogMode, setDialogMode] = useState<'create' | 'edit'>('create');
   const [selectedMapping, setSelectedMapping] = useState<PIQBOMapping | undefined>(undefined);
   const [loading, setLoading] = useState(true);
+  const [piSearchTerm, setPiSearchTerm] = useState("");
+  const [qboSearchTerm, setQboSearchTerm] = useState("");
   
   const { toast } = useToast();
   const { user, isLoaded } = useUser();
@@ -165,6 +169,14 @@ export default function PIQBOMappingsPage() {
     }
   };
 
+  const filteredTableData = tableData.filter((item) => {
+    const matchesPI = piSearchTerm === "" || 
+      item.piName.toLowerCase().includes(piSearchTerm.toLowerCase());
+    const matchesQBO = qboSearchTerm === "" || 
+      item.qboName.toLowerCase().includes(qboSearchTerm.toLowerCase());
+    return matchesPI && matchesQBO;
+  });
+
   return (
     <div className="container mx-auto py-6">
       <div className="flex justify-between items-center mb-6">
@@ -180,10 +192,37 @@ export default function PIQBOMappingsPage() {
           <p>Loading...</p>
         </div>
       ) : (
-        <PIQBOMappingTable
-          columns={columns(handleEditMapping, handleDeleteMapping)}
-          data={tableData}
-        />
+        <>
+          <div className="flex gap-4 mb-4">
+            <div className="flex-1">
+              <Label htmlFor="pi-search" className="text-sm font-medium mb-2 block">
+                Search by Output name
+              </Label>
+              <Input
+                placeholder="Search by Output name..."
+                value={piSearchTerm}
+                onChange={(e) => setPiSearchTerm(e.target.value)}
+                className="max-w-sm"
+              />
+            </div>
+            <div className="flex-1">
+              <Label htmlFor="qbo-search" className="text-sm font-medium mb-2 block">
+                Search by Outcome name
+              </Label>
+              <Input
+                placeholder="Search by Outcome name..."
+                value={qboSearchTerm}
+                onChange={(e) => setQboSearchTerm(e.target.value)}
+                className="max-w-sm"
+              />
+            </div>
+          </div>
+
+          <PIQBOMappingTable
+            columns={columns(handleEditMapping, handleDeleteMapping)}
+            data={filteredTableData} 
+          />
+        </>
       )}
 
       <PIQBOMappingDialog

--- a/components/pi-job-mapping/table/pi-job-mapping-table.tsx
+++ b/components/pi-job-mapping/table/pi-job-mapping-table.tsx
@@ -88,6 +88,21 @@ export function MappingJPTable<TData, TValue>({
               </TableCell>
             </TableRow>
           )}
+          {table.getRowModel().rows?.length > 0 && (
+            <TableRow className="bg-gray-50">
+              <TableCell colSpan={3} className="text-right font-medium">
+                Total Impact:
+              </TableCell>
+              
+              <TableCell className="font-medium">
+                {data.reduce((sum, item: any) => sum + (item.piImpactValue || 0), 0)}
+              </TableCell>
+              
+              <TableCell></TableCell>
+              
+              <TableCell></TableCell>
+            </TableRow>
+)}
         </TableBody>
       </Table>
     </div>


### PR DESCRIPTION
Added the filter functionality to the backstage mapping tables as requested. Users can now easily filter the PI-Job and PI-QBO mapping tables by searching for specific output names, job names, or outcome names. Typing in the search fields filters tables in real time. You can also search by (both job and PI in job-output table) OR (both PI and QBO in output-outcome table) at the same time to get specific results. Also added a "Total Impact" summary row to the PI-Job mapping table to match the existing functionality in the PI-QBO table. The impact score shows total based on filtered data in the table.