### PR TITLE
Remove getCalendar error cluttering up console

### DIFF
--- a/lib/services/google.calendar.provider.ts
+++ b/lib/services/google.calendar.provider.ts
@@ -33,8 +33,7 @@ export async function getCalendar(
     const calendar = google.calendar({ version: "v3", auth: oauth2Client });
     return calendar;
   } catch (error) {
-    console.log("Error in getCalendar" + error);
-    throw new Error("Error getting calendar object");
+    console.error("Error in getCalendar" + error);
   }
 }
 


### PR DESCRIPTION
Resolves issue of getting repeated console errors every time notification service checks calendars (every 60 s).