### PR TITLE
315 accessible job task sidebars

### DIFF
--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -63,7 +63,14 @@ export async function PUT(
     
     const { id } = await params;
     const updateData = await request.json();
-    const updatedTask = await taskService.updateTask(id, userId!, updateData);
+
+    let updatedTask;
+    if (typeof updateData.completed === 'boolean') {
+      // Use markCompleted to ensure endDate and timeElapsed are set
+      updatedTask = await taskService.markCompleted(id, userId!, updateData.completed);
+    } else {
+      updatedTask = await taskService.updateTask(id, userId!, updateData);
+    }
    
     if (!updatedTask) {
       return NextResponse.json(

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -40,7 +40,7 @@ const SearchPage = () => {
           const jobsMap: Record<string, any> = {};
           result.data.forEach((job: any) => {
             if (job._id) {
-              jobsMap[job._id] = job;
+              jobsMap[job._id] = { ...job, id: job._id };
             }
           });
           setJobs(jobsMap);
@@ -228,6 +228,14 @@ const SearchPage = () => {
     setNeedsRefresh(n => !n);
   };
 
+  const handleNavigateToJob = (jobId: string) => {
+    if (jobs[jobId]) {
+      setCurrentJob(jobs[jobId]);
+      setTaskSidebarOpen(true);
+      setSidebarOpen(false);
+    }
+  };
+
   return (
     <div className="p-4">
       <div className="container mx-auto py-10">
@@ -279,15 +287,17 @@ const SearchPage = () => {
           selectedTask={currentItem}
           onTaskUpdated={handleTaskUpdated}
           onDeleteTask={handleDeleteItem}
+          onNavigateToJob={handleNavigateToJob}
         />
 
         {/* Tasks Sidebar - For jobs */}
         <TasksSidebar
           open={taskSidebarOpen}
           onOpenChange={handleTaskSidebarChange}
-          selectedJob={currentJob}
+          selectedJob={currentJob ? { ...currentJob, id: currentJob.id ?? currentJob._id } : null}
           onRefreshJobs={() => setNeedsRefresh(n => !n)}
           onDeleteJob={handleDeleteItem}
+          jobs={jobs}
         />
 
         {/* Task Edit Dialog */}
@@ -299,6 +309,7 @@ const SearchPage = () => {
             onSubmit={handleTaskSubmit}
             initialData={editingItem}
             jobs={jobs}
+            jobId={editingItem?.jobId}
           />
         )}
 

--- a/components/tasks/feed/tasks.tsx
+++ b/components/tasks/feed/tasks.tsx
@@ -9,6 +9,7 @@ import {
   Smile,
   FileText,
   PawPrint,
+  Target
 } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
@@ -286,8 +287,8 @@ export function NextTasks({
                           )}`}
                           fill="currentColor"
                         />
-                        <span className="text-sm">
-                          Focus: {task.focusLevel}
+                        <span className="text-sm text-gray-600">
+                          Focus: <span className="text-sm font-bold">{task.focusLevel}</span>
                         </span>
                       </div>
                     )}
@@ -299,22 +300,22 @@ export function NextTasks({
                             task.joyLevel,
                           )}`}
                         />
-                        <span className="text-sm">Joy: {task.joyLevel}</span>
+                        <span className="text-sm text-gray-600">Joy: <span className="text-sm font-bold">{task.joyLevel}</span></span>
                       </div>
                     )}
 
                     {task.date && (
                       <div className="flex items-center text-muted-foreground">
                         <Calendar className="h-4 w-4 mr-1" />
-                        <span className="text-sm">{formatDate(task.date)}</span>
+                        <span className="text-sm text-gray-600">Do Date: <span className="text-sm font-bold">{formatDate(task.date)}</span></span>
                       </div>
                     )}
 
                     {task.requiredHours !== undefined && (
                       <div className="flex items-center text-muted-foreground">
                         <Clock className="h-4 w-4 mr-1" />
-                        <span className="text-sm">
-                          {task.requiredHours} hrs
+                        <span className="text-sm text-gray-600">
+                          Hrs Reqd: <span className="text-sm font-bold">{task.requiredHours} hrs</span>
                         </span>
                       </div>
                     )}

--- a/components/tasks/task-details-sidebar.tsx
+++ b/components/tasks/task-details-sidebar.tsx
@@ -38,11 +38,13 @@ import {
   Plus,
   RefreshCcw,
   Tag,
-  Edit
+  Edit,
+  ChevronRight
 } from "lucide-react";
 import { Task, RecurrenceInterval } from "@/components/tasks/types";
 import { JobDialog } from "@/components/jobs/job-dialog";
 import { useToast } from "@/hooks/use-toast";
+import Link from 'next/link';
 
 interface TaskDetailsSidebarTask extends Task {
 
@@ -617,7 +619,9 @@ const cancelEditing = () => {
     if (result.success) {
       const updatedTask: TaskDetailsSidebarTask = {
         ...taskDetails,
+        ...result.data, // Use all updated fields from API, including endDate and timeElapsed
         completed,
+        ...(completed === false ? { endDate: undefined, timeElapsed: undefined } : {}),
       };
 
       setTaskDetails(updatedTask);
@@ -1057,9 +1061,25 @@ const cancelEditing = () => {
                   </div>
                   {/* Job Information - Editable */}
                   <div className="mb-4 pb-4 border-b">
-                    <div className="flex items-center mb-2">
-                      <Briefcase className="h-4 w-4 mr-2 text-gray-500" />
-                      <h3 className="text-sm font-semibold">Job</h3>
+                    <div className="flex items-center mb-2 justify-between">
+                      <div className="flex items-center">
+                        <Briefcase className="h-4 w-4 mr-2 text-gray-500" />
+                        <h3 className="text-sm font-semibold">Job</h3>
+                      </div>
+                      {jobInfo && onNavigateToJob && (
+                        <button
+                          className="flex items-center gap-1 text-xs px-2 py-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground font-medium"
+                          type="button"
+                          onClick={e => {
+                            e.stopPropagation();
+                            onOpenChange(false);
+                            setTimeout(() => onNavigateToJob(jobInfo.id), 150);
+                          }}
+                        >
+                          View Job
+                          <ChevronRight className="h-3 w-3" />
+                        </button>
+                      )}
                     </div>
                     <div className="pl-6">
                       {editingField === 'job' ? (
@@ -1111,11 +1131,11 @@ const cancelEditing = () => {
                         </div>
                       ) : (
                         <div 
-                          className="cursor-pointer hover:bg-gray-100 rounded px-2 py-1 transition-colors group relative"
+                          className="cursor-pointer hover:bg-gray-100 rounded px-2 py-1 transition-colors group relative flex items-center gap-2"
                           onClick={() => startEditing('job', taskDetails.jobId)}
                         >
                           {jobInfo ? (
-                            <div>
+                            <>
                               <div className="flex items-center gap-2">
                                 <span className="text-sm font-medium">{jobInfo.title}</span>
                                 {jobInfo.jobNumber && (
@@ -1124,7 +1144,7 @@ const cancelEditing = () => {
                                   </span>
                                 )}
                               </div>
-                            </div>
+                            </>
                           ) : (
                             <span className="text-sm text-gray-500">No job assigned</span>
                           )}
@@ -1336,6 +1356,35 @@ const cancelEditing = () => {
       )}
     </div>
   </div>
+
+{/* Non-editable, greyed-out fields for createdDate, endDate, and duration */}
+<div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+  <div className="flex items-center gap-2 bg-gray-50 rounded p-2">
+    <Calendar className="h-4 w-4 text-gray-400" />
+    <div>
+      <div className="text-xs text-gray-500">Created</div>
+      <div className="text-sm text-gray-400 select-none">{formatDate((taskDetails.createdDate instanceof Date ? taskDetails.createdDate.toISOString() : taskDetails.createdDate) as string)}</div>
+    </div>
+  </div>
+  {taskDetails.completed && (
+    <>
+      <div className="flex items-center gap-2 bg-gray-50 rounded p-2">
+        <Clock className="h-4 w-4 text-gray-400" />
+        <div>
+          <div className="text-xs text-gray-500">Completed</div>
+          <div className="text-sm text-gray-400 select-none">{taskDetails.endDate ? formatDate((taskDetails.endDate instanceof Date ? taskDetails.endDate.toISOString() : taskDetails.endDate) as string) : '—'}</div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 bg-gray-50 rounded p-2">
+        <BarChart className="h-4 w-4 text-gray-400" />
+        <div>
+          <div className="text-xs text-gray-500">Duration</div>
+          <div className="text-sm text-gray-400 select-none">{taskDetails.timeElapsed || '—'}</div>
+        </div>
+      </div>
+    </>
+  )}
+</div>
                   </div>
                 </CardContent>
               </Card>

--- a/components/tasks/tasks-card.tsx
+++ b/components/tasks/tasks-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Edit, Trash2, Clock, Calendar, PawPrint, ChevronDown, ChevronUp, RefreshCcw } from "lucide-react";
+import { Edit, Trash2, Clock, Calendar, PawPrint, ChevronDown, ChevronUp, RefreshCcw, Target, Smile } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -44,7 +44,6 @@ export function TaskCard({
     const router = useRouter();
     const [isHovered, setIsHovered] = useState(false);
     const { refreshJobProgress } = useTaskContext();
-    const [showDetails, setShowDetails] = useState(false);
 
     // Format the date
     const formatDate = (dateString?: string) => {
@@ -161,30 +160,30 @@ export function TaskCard({
                             <div className="flex items-center gap-10">
                                 {task.focusLevel && (
                                     <div className="flex items-center">
-                                        <span className="text-gray-500 mr-2">focus:</span>
-                                        <span className="text-sm">{task.focusLevel}</span>
+                                        <span className="text-sm text-gray-600">Focus:  <span className="text-sm font-bold">{task.focusLevel}</span></span>
+                                       
                                     </div>
                                 )}
                                 {task.joyLevel && (
                                     <div className="flex items-center">
-                                        <span className="text-gray-500 mr-2">Joy:</span>
-                                        <span className="text-sm">{task.joyLevel}</span>
+                                        <span className="text-sm text-gray-600">Joy: <span className="text-sm font-bold">{task.joyLevel}</span></span>
+                                        
                                     </div>
                                 )}
 
                                 {/* Date */}
                                 {task.date && (
                                     <div className="flex items-center">
-                                        <Calendar className="h-4 w-4 text-gray-500 mr-2" />
-                                        <span className="text-sm text-gray-600">{formatDate(task.date)}</span>
+                                        {/* <Calendar className="h-4 w-4 text-gray-500 mr-2" /> */}
+                                        <span className="text-sm text-gray-600">Do Date: <span className="text-sm font-bold">{formatDate(task.date)}</span></span>
                                     </div>
                                 )}
 
                                 {/* Required hours */}
                                 {task.requiredHours !== undefined && (
                                     <div className="flex items-center">
-                                        <Clock className="h-4 w-4 text-gray-500 mr-2" />
-                                        <span className="text-sm text-gray-600">{task.requiredHours} hrs</span>
+                                        {/* <Clock className="h-4 w-4 text-gray-500 mr-2" /> */}
+                                        <span className="text-sm text-gray-600">Hrs Reqd: <span className="text-sm font-bold">{task.requiredHours} hrs</span></span>
                                     </div>
                                 )}
                             </div>
@@ -203,51 +202,6 @@ export function TaskCard({
                                     </Badge>
                                 ))}
                             </div>
-                        )}
-                        {/* Time tracking details dropdown */}
-                        {(task.createdDate || task.endDate || task.timeElapsed) && (
-                        <div className="mt-3">
-                            <button
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    setShowDetails(!showDetails);
-                                }}
-                                className="flex items-center text-xs text-gray-500 hover:text-gray-700 transition-colors"
-                            >
-                                <Clock className="h-3 w-3 mr-1" />
-                                <span>Details</span>
-                                {showDetails ? (
-                                    <ChevronUp className="h-3 w-3 ml-1" />
-                                ) : (
-                                    <ChevronDown className="h-3 w-3 ml-1" />
-                                )}
-                            </button>
-                            
-                            {showDetails && (
-                            <div className="mt-2 p-2 rounded text-xs">
-                                <div className="flex items-center justify-between gap-4">
-                                {task.createdDate && (
-                                    <div className="flex items-center gap-1">
-                                    <span className="text-gray-500">Created:</span>
-                                    <span>{formatTimestamp(task.createdDate)}</span>
-                                    </div>
-                                )}
-                                {task.endDate && (
-                                    <div className="flex items-center gap-1">
-                                    <span className="text-gray-500">Completed:</span>
-                                    <span>{formatTimestamp(task.endDate)}</span>
-                                    </div>
-                                )}
-                                {task.timeElapsed && (
-                                    <div className="flex items-center gap-1">
-                                    <span className="text-gray-500">Duration:</span>
-                                    <span className="font-medium">{task.timeElapsed}</span>
-                                    </div>
-                                )}
-                                </div>
-                            </div>
-                            )}
-                        </div>
                         )}
                     </div>
 

--- a/components/tasks/tasks-card.tsx
+++ b/components/tasks/tasks-card.tsx
@@ -235,7 +235,7 @@ export function TaskCard({
                         </Button>
                         <AlertDialog>
                             <AlertDialogTrigger asChild>
-                                <Button variant="ghost" size="icon" className="h-8 w-8" onClick={e => e.stopPropagation()}>
+                                <Button variant="ghost" size="icon" className="h-8 w-8" onClick={e => e.stopPropagation()} title="Delete Task">
                                     <Trash2 className="h-4 w-4" />
                                 </Button>
                             </AlertDialogTrigger>


### PR DESCRIPTION
1. The job and task sidebar are now accessible from the outcome decision tree's job and task blocks. 
2. The details dropdown under task cards within the job sidebar has been removed, and the createdDate, endDate and duration details for each task are moved into the task-details-sidebar. 
3. Task details sidebar now has a hyperlink to go to the parent job. 
4. Icons for Do-date and Hours Required are removed and replaced with labels in task cards. 
5. The Focus label in task cards is capitalized. 
6. All values for focus, joy, do-date and hours required in the task cards are bolded.