### PR TITLE
Implemented comprehensive organization duplication with complete data preservation and smart naming

### DIFF
--- a/app/api/organizations/[id]/duplicate/route.ts
+++ b/app/api/organizations/[id]/duplicate/route.ts
@@ -1,0 +1,41 @@
+// app/api/organizations/[id]/duplicate/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { validateAuth } from "@/lib/utils/auth-utils";
+import { OrganizationService } from "@/lib/services/organization.service";
+
+const orgService = new OrganizationService();
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await validateAuth();
+
+  if (!authResult.isAuthorized) {
+    return authResult.response;
+  }
+
+  // Get the actual user ID, not the view ID
+  const userId = authResult.actualUserId;
+  const { id } = await params;
+
+  try {
+    const duplicatedOrg = await orgService.duplicateOrganization(id, userId!);
+
+    return NextResponse.json({
+      success: true,
+      data: duplicatedOrg,
+      message: "Organization duplicated successfully",
+    });
+  } catch (error) {
+    console.error("Error duplicating organization:", error);
+    
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to duplicate organization",
+      },
+      { status: 400 },
+    );
+  }
+}

--- a/lib/services/organization.service.ts
+++ b/lib/services/organization.service.ts
@@ -3,6 +3,18 @@ import Organization, {
   Organization as OrganizationType,
 } from "@/lib/models/organization.model";
 import UserOrganization from "@/lib/models/userOrganization.model";
+import Job from "@/lib/models/job.model";
+import Task from "@/lib/models/task.model";
+import BusinessFunction from "@/lib/models/business-function.model";
+import Owner from "@/lib/models/owner.model";
+import QBO from "@/lib/models/qbo.model";
+import PI from "@/lib/models/pi.model";
+import PIJobMapping from "@/lib/models/pi-job-mapping.model";
+import PIQBOMapping from "@/lib/models/pi-qbo-mapping.model";
+import BusinessInfo from "@/lib/models/business-info.model";
+import Note from "@/lib/models/note.model";
+import TaskTag from "@/lib/models/task-tag.model";
+import Chat from "@/lib/models/chat.model";
 import dbConnect from "../mongodb";
 
 export class OrganizationService {
@@ -73,5 +85,279 @@ export class OrganizationService {
     );
 
     return !!result;
+  }
+
+  async duplicateOrganization(originalOrgId: string, userId: string) {
+    await dbConnect();
+    
+    // Check if user has admin access to the original organization
+    const userOrg = await UserOrganization.findOne({
+      userId,
+      organizationId: originalOrgId,
+      role: "admin",
+    });
+
+    if (!userOrg) {
+      throw new Error("You don't have permission to duplicate this organization");
+    }
+
+    // Get the original organization
+    const originalOrg = await Organization.findById(originalOrgId);
+    if (!originalOrg) {
+      throw new Error("Original organization not found");
+    }
+
+    // Create new organization with smart naming (like file systems)
+    let newOrgName = `${originalOrg.name} copy`;
+    let counter = 1;
+    
+    // Check if the name already exists and increment counter if needed
+    while (await Organization.findOne({ name: newOrgName, isDeleted: { $ne: true } })) {
+      newOrgName = `${originalOrg.name} copy (${counter})`;
+      counter++;
+    }
+    
+    const newOrg = new Organization({
+      name: newOrgName,
+      description: originalOrg.description,
+      createdBy: userId,
+    });
+    const savedNewOrg = await newOrg.save();
+
+    // Add user as admin to the new organization
+    await UserOrganization.create({
+      userId,
+      organizationId: savedNewOrg._id.toString(),
+      role: "admin",
+    });
+
+    // Get all users in the original organization to add them to the new one
+    const originalOrgUsers = await UserOrganization.find({
+      organizationId: originalOrgId,
+    });
+
+    // Add all users from original org to new org (except the current user who's already added)
+    for (const userOrg of originalOrgUsers) {
+      if (userOrg.userId !== userId) {
+        await UserOrganization.create({
+          userId: userOrg.userId,
+          organizationId: savedNewOrg._id.toString(),
+          role: userOrg.role,
+        });
+      }
+    }
+
+    // Duplicate business info
+    const businessInfo = await BusinessInfo.findOne({ userId: originalOrgId });
+    if (businessInfo) {
+      await BusinessInfo.create({
+        name: businessInfo.name,
+        industry: businessInfo.industry,
+        missionStatement: businessInfo.missionStatement,
+        monthsInBusiness: businessInfo.monthsInBusiness,
+        annualRevenue: businessInfo.annualRevenue,
+        growthStage: businessInfo.growthStage,
+        userId: savedNewOrg._id.toString(),
+      });
+    }
+
+    // Duplicate business functions first
+    const businessFunctions = await BusinessFunction.find({ userId: originalOrgId });
+    const businessFunctionMap = new Map();
+    
+    for (const bf of businessFunctions) {
+      const newBf = new BusinessFunction({
+        name: bf.name,
+        userId: savedNewOrg._id.toString(),
+        isDefault: bf.isDefault,
+        isHidden: bf.isHidden,
+      });
+      const savedBf = await newBf.save();
+      businessFunctionMap.set(bf._id.toString(), savedBf._id.toString());
+    }
+
+    // Duplicate owners
+    const owners = await Owner.find({ userId: originalOrgId });
+    const ownerMap = new Map();
+    
+    for (const owner of owners) {
+      const newOwner = new Owner({
+        name: owner.name,
+        userId: savedNewOrg._id.toString(),
+      });
+      const savedOwner = await newOwner.save();
+      ownerMap.set(owner._id.toString(), savedOwner._id.toString());
+    }
+
+    // Duplicate PIs
+    const pis = await PI.find({ userId: originalOrgId });
+    const piMap = new Map();
+    
+    for (const pi of pis) {
+      const newPi = new PI({
+        name: pi.name,
+        unit: pi.unit,
+        beginningValue: pi.beginningValue,
+        targetValue: pi.targetValue,
+        deadline: pi.deadline,
+        notes: pi.notes,
+        userId: savedNewOrg._id.toString(),
+      });
+      const savedPi = await newPi.save();
+      piMap.set(pi._id.toString(), savedPi._id.toString());
+    }
+
+    // Duplicate QBOs
+    const qbos = await QBO.find({ userId: originalOrgId });
+    const qboMap = new Map();
+    
+    for (const qbo of qbos) {
+      const newQbo = new QBO({
+        name: qbo.name,
+        unit: qbo.unit,
+        beginningValue: qbo.beginningValue,
+        currentValue: qbo.currentValue,
+        targetValue: qbo.targetValue,
+        deadline: qbo.deadline,
+        points: qbo.points,
+        notes: qbo.notes,
+        userId: savedNewOrg._id.toString(),
+      });
+      const savedQbo = await newQbo.save();
+      qboMap.set(qbo._id.toString(), savedQbo._id.toString());
+    }
+
+    // Duplicate jobs with preserved completion status
+    const originalJobs = await Job.find({ userId: originalOrgId, isDeleted: { $ne: true } });
+    const jobMap = new Map();
+    
+    for (const job of originalJobs) {
+      const newBusinessFunctionId = businessFunctionMap.get(job.businessFunctionId) || job.businessFunctionId;
+      
+      const newJob = new Job({
+        title: job.title,
+        notes: job.notes,
+        businessFunctionId: newBusinessFunctionId,
+        userId: savedNewOrg._id.toString(),
+        dueDate: job.dueDate,
+        createdDate: job.createdDate,
+        isDone: job.isDone, // Preserve completion status
+        impact: job.impact,
+        isDeleted: false,
+        jobNumber: job.jobNumber,
+        isRecurring: job.isRecurring,
+        recurrenceInterval: job.recurrenceInterval,
+      });
+      const savedJob = await newJob.save();
+      jobMap.set(job._id.toString(), savedJob._id.toString());
+    }
+
+    // Duplicate tasks with preserved completion status and My Day assignments
+    const originalTasks = await Task.find({ userId: originalOrgId, isDeleted: { $ne: true } });
+    
+    for (const task of originalTasks) {
+      const newJobId = jobMap.get(task.jobId);
+      if (!newJobId) continue; // Skip if job wasn't duplicated
+      
+      const newOwner = task.owner ? ownerMap.get(task.owner) : undefined;
+      
+      const newTask = new Task({
+        title: task.title,
+        owner: newOwner,
+        date: task.date,
+        requiredHours: task.requiredHours,
+        focusLevel: task.focusLevel,
+        joyLevel: task.joyLevel,
+        notes: task.notes,
+        tags: task.tags,
+        jobId: newJobId,
+        userId: savedNewOrg._id.toString(),
+        completed: task.completed, // Preserve completion status
+        isDeleted: false,
+        createdDate: task.createdDate,
+        endDate: task.endDate,
+        timeElapsed: task.timeElapsed,
+        isRecurring: task.isRecurring,
+        recurrenceInterval: task.recurrenceInterval,
+        myDay: task.myDay, // Preserve My Day status
+        myDayDate: task.myDayDate, // Preserve My Day date
+      });
+      
+      await newTask.save();
+    }
+
+    // Duplicate PI-Job mappings
+    const piJobMappings = await PIJobMapping.find({ userId: originalOrgId });
+    for (const mapping of piJobMappings) {
+      const newJobId = jobMap.get(mapping.jobId);
+      const newPiId = piMap.get(mapping.piId);
+      
+      if (newJobId && newPiId) {
+        await PIJobMapping.create({
+          jobId: newJobId,
+          piId: newPiId,
+          jobName: mapping.jobName,
+          piName: mapping.piName,
+          piImpactValue: mapping.piImpactValue,
+          piTarget: mapping.piTarget,
+          notes: mapping.notes,
+          userId: savedNewOrg._id.toString(),
+        });
+      }
+    }
+
+    // Duplicate PI-QBO mappings
+    const piQboMappings = await PIQBOMapping.find({ userId: originalOrgId });
+    for (const mapping of piQboMappings) {
+      const newPiId = piMap.get(mapping.piId);
+      const newQboId = qboMap.get(mapping.qboId);
+      
+      if (newPiId && newQboId) {
+        await PIQBOMapping.create({
+          piId: newPiId,
+          qboId: newQboId,
+          piName: mapping.piName,
+          qboName: mapping.qboName,
+          piTarget: mapping.piTarget,
+          qboTarget: mapping.qboTarget,
+          qboImpact: mapping.qboImpact,
+          notes: mapping.notes,
+          userId: savedNewOrg._id.toString(),
+        });
+      }
+    }
+
+    // Duplicate notes
+    const notes = await Note.find({ userId: originalOrgId });
+    for (const note of notes) {
+      await Note.create({
+        title: note.title,
+        content: note.content,
+        userId: savedNewOrg._id.toString(),
+      });
+    }
+
+    // Duplicate task tags
+    const taskTags = await TaskTag.find({ userId: originalOrgId });
+    for (const tag of taskTags) {
+      await TaskTag.create({
+        name: tag.name,
+        userId: savedNewOrg._id.toString(),
+      });
+    }
+
+    // Duplicate chat history
+    const chats = await Chat.find({ userId: originalOrgId });
+    for (const chat of chats) {
+      await Chat.create({
+        userId: savedNewOrg._id.toString(),
+        chatId: chat.chatId,
+        messages: chat.messages,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    }
+
+    return savedNewOrg;
   }
 }


### PR DESCRIPTION
Users with admin access can now duplicate organizations with all associated data and statuses preserved. The feature includes complete data copying (business functions, QBOs, PIs, jobs, tasks, owners, notes, chat history, and all relationships) with smart naming to prevent conflicts. Jobs and tasks maintain their completion status (isDone, completed), My Day assignments (myDay and myDayDate), and time tracking data. Newly duplicated orgs have the same name as the original with a "copy" tag, with automatic numbering for multiple copies (e.g., "copy", "copy (1)"). Changes in duplicate don't affect original and vice versa.

To duplicate an org, go to settings > basic settings tab > Organization > The action column has a duplicate action button present.